### PR TITLE
scripts/rke22ext: move rke2 binary in /usr/bin

### DIFF
--- a/scripts/rke22ext.sh
+++ b/scripts/rke22ext.sh
@@ -21,8 +21,8 @@ PRINTHELP=0
 : ${TARGET_ARCH:="amd64"}
 : ${RKE2_VER:="v1.32.1+rke2r1"}
 
-: ${ID:="sl-micro"}
-: ${VERSION_ID:="6.1"}
+: ${ID:="_any"}
+: ${VERSION_ID:=""}
 : ${EXTENSION_RELOAD_MANAGER:="1"}
 : ${REPO:="localhost"}
 


### PR DESCRIPTION
By default, rke2 tar archive assumes RKE2 binaries to be installed in /usr/local/bin. SL Micro and MicroOS >= 6.2 wouldn't merge correctly extension images with the /usr/local path.
Moreover, the recommended place for extension image binaries is NOT /usr/local/bin.
Move rke2 binary to /usr/bin.
    
Fixes #1
